### PR TITLE
Add Cleaned Data via upload

### DIFF
--- a/data/cleaned_data/TopicModeling.ipynb
+++ b/data/cleaned_data/TopicModeling.ipynb
@@ -1,0 +1,408 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "3a6f21fe-4f91-443f-b7df-e2b748058300",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[nltk_data] Downloading package stopwords to\n",
+      "[nltk_data]     /usr4/cs505ws/chrisyan/nltk_data...\n",
+      "[nltk_data]   Package stopwords is already up-to-date!\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "import pandas as pd\n",
+    "import re\n",
+    "import nltk\n",
+    "from nltk.corpus import stopwords\n",
+    "nltk.download('stopwords')\n",
+    "from nltk.stem import WordNetLemmatizer\n",
+    " \n",
+    "lemmatizer = WordNetLemmatizer()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "9e1c1cee-7db8-4f27-87f3-9c0c081c5e7d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dfArticleOne = pd.read_csv('articles1.csv')\n",
+    "dfArticleOne = dfArticleOne.content.astype(str) + dfArticleOne.title.astype(str) \n",
+    "dfArticleTwo = pd.read_csv('articles2.csv')\n",
+    "dfArticleTwo = dfArticleTwo.content.astype(str)  + dfArticleTwo.title.astype(str) \n",
+    "dfArticleThree = pd.read_csv('articles3.csv')\n",
+    "dfArticleThree = dfArticleThree.content.astype(str)  + dfArticleThree.title.astype(str) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "5885581a-903a-4da4-b144-d73d2bd76af2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dfArticleCNN = pd.read_csv('CNN_Articels_clean 2.csv')\n",
+    "dfArticleCNN = dfArticleCNN[\"Article text\"].astype(str)  + dfArticleCNN[\"Second headline\"].astype(str)  + dfArticleCNN[\"Headline\"].astype(str) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "a2faed75-a0e1-475f-b549-768ff31e7b7c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dfArticleBBC = pd.read_csv('bbc-news-data.csv', sep ='\\t')\n",
+    "dfArticleBBC = dfArticleBBC[\"title\"].astype(str)  + dfArticleBBC[\"content\"].astype(str) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "a89bd3b2-1bba-4513-8264-e700722f8ea2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def textPreprocessArticles(data):\n",
+    "    # Change the pandas into list\n",
+    "    content_list = data.tolist()\n",
+    "    \n",
+    "    # lower case the words and split them into a list \n",
+    "    new_list = [x.lower().split() for x in content_list]\n",
+    "\n",
+    "    # Some texts have location followed by \"-\" at the beginning of the article --> delete them if it contains them\n",
+    "    for article in range(len(new_list)):\n",
+    "        for word in range(len(new_list[article])):\n",
+    "            if word <= 7 and new_list[article][word] == '—':\n",
+    "                new_list[article] = new_list[article][word + 1:]\n",
+    "                break\n",
+    "            if word >= 8:\n",
+    "                break\n",
+    "\n",
+    "    # delete the numbers and punctuations\n",
+    "    word_list = [[re.sub(r'\\d+|[^\\w\\s]', '', word) for word in article] for article in new_list]\n",
+    "\n",
+    "    # Delete the stopwords and the words that have length less than or equal to 2\n",
+    "    stop = stopwords.words('english')\n",
+    "    remove_stopword = []\n",
+    "    for article in word_list:\n",
+    "        lst = [x for x in article if x not in stop and len(x) >= 3]\n",
+    "        remove_stopword.append(lst)\n",
+    "\n",
+    "    # Perform Lemminzation \n",
+    "    stem_lemma_lst = [[lemmatizer.lemmatize(str) for str in lst] for lst in remove_stopword]\n",
+    "    return stem_lemma_lst\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "11c686de-52f2-4a5f-a820-0283da3c98f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dfArticleOne = textPreprocessArticles(dfArticleOne)\n",
+    "dfArticleTwo = textPreprocessArticles(dfArticleTwo)\n",
+    "dfArticleThree = textPreprocessArticles(dfArticleThree)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "2a7e24da-37b6-48a4-b3ea-9464b47cb876",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[['congressional', 'republican', 'new', 'fear', 'come', 'health', 'care', 'lawsuit', 'obama', 'administration', 'might', 'win', 'incoming', 'trump', 'administration', 'could', 'choose', 'longer', 'defend', 'executive', 'branch', 'suit', 'challenge', 'administration', 'authority', 'spend', 'billion', 'dollar', 'health', 'insurance', 'subsidy', 'american', 'handing', 'house', 'republican', 'big', 'victory', 'issue', 'sudden', 'loss', 'disputed', 'subsidy', 'could', 'conceivably', 'cause', 'health', 'care', 'program', 'implode', 'leaving', 'million', 'people', 'without', 'access', 'health', 'insurance', 'republican', 'prepared', 'replacement', 'could', 'lead', 'chaos', 'insurance', 'market', 'spur', 'political', 'backlash', 'republican', 'gain', 'full', 'control', 'government', 'stave', 'outcome', 'republican', 'could', 'find', 'awkward', 'position', 'appropriating', 'huge', 'sum', 'temporarily', 'prop', 'obama', 'health', 'care', 'law', 'angering', 'conservative', 'voter', 'demanding', 'end', 'law', 'year', 'another', 'twist', 'donald', 'trump', 'administration', 'worried', 'preserving', 'executive', 'branch', 'prerogative', 'could', 'choose', 'fight', 'republican', 'ally', 'house', 'central', 'question', 'dispute', 'eager', 'avoid', 'ugly', 'political', 'pileup', 'republican', 'capitol', 'hill', 'trump', 'transition', 'team', 'gaming', 'handle', 'lawsuit', 'election', 'put', 'limbo', 'least', 'late', 'february', 'united', 'state', 'court', 'appeal', 'district', 'columbia', 'circuit', 'yet', 'ready', 'divulge', 'strategy', 'given', 'pending', 'litigation', 'involves', 'obama', 'administration', 'congress', 'would', 'inappropriate', 'comment', 'said', 'phillip', 'blando', 'spokesman', 'trump', 'transition', 'effort', 'upon', 'taking', 'office', 'trump', 'administration', 'evaluate', 'case', 'related', 'aspect', 'affordable', 'care', 'act', 'potentially', 'decision', 'judge', 'rosemary', 'collyer', 'ruled', 'house', 'republican', 'standing', 'sue', 'executive', 'branch', 'spending', 'dispute', 'obama', 'administration', 'distributing', 'health', 'insurance', 'subsidy', 'violation', 'constitution', 'without', 'approval', 'congress', 'justice', 'department', 'confident', 'judge', 'collyers', 'decision', 'would', 'reversed', 'quickly', 'appealed', 'subsidy', 'remained', 'place', 'appeal', 'successfully', 'seeking', 'temporary', 'halt', 'proceeding', 'trump', 'house', 'republican', 'last', 'month', 'told', 'court', 'transition', 'team', 'currently', 'discussing', 'potential', 'option', 'resolution', 'matter', 'take', 'effect', 'inauguration', 'jan', 'suspension', 'case', 'house', 'lawyer', 'said', 'provide', 'future', 'administration', 'time', 'consider', 'whether', 'continue', 'prosecuting', 'otherwise', 'resolve', 'appeal', 'republican', 'leadership', 'official', 'house', 'acknowledge', 'possibility', 'cascading', 'effect', 'payment', 'totaled', 'estimated', 'billion', 'suddenly', 'stopped', 'insurer', 'receive', 'subsidy', 'exchange', 'paying', 'cost', 'deductible', 'eligible', 'consumer', 'could', 'race', 'drop', 'coverage', 'since', 'would', 'losing', 'money', 'loss', 'subsidy', 'could', 'destabilize', 'entire', 'program', 'cause', 'lack', 'confidence', 'lead', 'insurer', 'seek', 'quick', 'exit', 'well', 'anticipating', 'trump', 'administration', 'might', 'inclined', 'mount', 'vigorous', 'fight', 'house', 'republican', 'given', 'dim', 'view', 'health', 'care', 'law', 'team', 'lawyer', 'month', 'sought', 'intervene', 'case', 'behalf', 'two', 'participant', 'health', 'care', 'program', 'request', 'lawyer', 'predicted', 'deal', 'house', 'republican', 'new', 'administration', 'dismiss', 'settle', 'case', 'produce', 'devastating', 'consequence', 'individual', 'receive', 'reduction', 'well', 'nation', 'health', 'insurance', 'health', 'care', 'system', 'generally', 'matter', 'happens', 'house', 'republican', 'say', 'want', 'prevail', 'two', 'overarching', 'concept', 'congressional', 'power', 'purse', 'right', 'congress', 'sue', 'executive', 'branch', 'violates', 'constitution', 'regarding', 'spending', 'power', 'house', 'republican', 'contend', 'congress', 'never', 'appropriated', 'money', 'subsidy', 'required', 'constitution', 'suit', 'initially', 'championed', 'john', 'boehner', 'house', 'speaker', 'time', 'later', 'house', 'committee', 'report', 'republican', 'asserted', 'administration', 'desperate', 'funding', 'required', 'treasury', 'department', 'provide', 'despite', 'widespread', 'internal', 'skepticism', 'spending', 'proper', 'white', 'house', 'said', 'spending', 'permanent', 'part', 'law', 'passed', 'annual', 'appropriation', 'required', 'even', 'though', 'administration', 'initially', 'sought', 'one', 'important', 'house', 'republican', 'judge', 'collyer', 'found', 'congress', 'standing', 'sue', 'white', 'house', 'issue', 'ruling', 'many', 'legal', 'expert', 'said', 'flawed', 'want', 'precedent', 'set', 'restore', 'congressional', 'leverage', 'executive', 'branch', 'spending', 'power', 'standing', 'trump', 'administration', 'may', 'come', 'pressure', 'advocate', 'presidential', 'authority', 'fight', 'house', 'matter', 'shared', 'view', 'health', 'care', 'since', 'precedent', 'could', 'broad', 'repercussion', 'complicated', 'set', 'dynamic', 'illustrating', 'quick', 'legal', 'victory', 'house', 'trump', 'era', 'might', 'come', 'cost', 'republican', 'never', 'anticipated', 'took', 'obama', 'white', 'househouse', 'republican', 'fret', 'winning', 'health', 'care', 'suit', 'new', 'york', 'time']]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(dfArticleOne[:1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "3ccbe2ca-fa86-47c0-9310-e30500463a09",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[['patriot', 'day', 'peter', 'berg', 'new', 'thriller', 'recreates', 'boston', 'marathon', 'bombing', 'ensuing', 'manhunt', 'followed', 'surprisingly', 'oblique', 'morally', 'ambiguous', 'movie', 'typically', 'straightforward', 'filmmaker', 'patriot', 'day', 'take', 'unexpectedly', 'cynical', 'view', 'chaos', 'rash', 'bureaucratic', 'infighting', 'followed', 'bombing', 'question', 'whether', 'berg', 'intended', 'message', 'grim', 'running', 'time', 'movie', 'celebrates', 'men', 'ground', 'helped', 'bring', 'bomber', 'justice', 'glimpse', 'something', 'complicated', 'jingoism', 'really', 'linger', 'scene', 'best', 'illustrates', 'dichotomy', 'come', 'late', 'patriot', 'day', 'search', 'one', 'bomber', 'dzhokhar', 'tsarnaev', 'intensifies', 'brother', 'wife', 'katherine', 'melissa', 'benoist', 'brought', 'interrogation', 'connection', 'case', 'asks', 'lawyer', 'protesting', 'right', 'steely', 'interviewer', 'khandi', 'alexander', 'tuts', 'honey', 'aint', 'got', 'shit', 'hollywood', 'line', 'intended', 'provoke', 'big', 'cheer', 'audience', 'despite', 'queasy', 'legal', 'undertone', 'film', 'present', 'cheesy', 'line', 'questioning', 'go', 'nowhere', 'interrogator', 'exit', 'shrug', 'movie', 'note', 'katherine', 'never', 'charged', 'crime', 'patriot', 'day', 'filled', 'kind', 'bluster', 'film', 'compelling', 'moment', 'serve', 'undercut', 'deepwater', 'horizon', 'stay', 'close', 'surface', 'working', 'interesting', 'theme', 'man', 'center', 'movie', 'boston', 'police', 'sergeant', 'tommy', 'saunders', 'fictional', 'character', 'invented', 'serve', 'audience', 'eye', 'ear', 'every', 'major', 'turning', 'point', 'attack', 'he', 'played', 'mark', 'wahlberg', 'polestar', 'berg', 'new', 'genre', 'storytelling', 'played', 'mouthy', 'hero', 'center', 'lone', 'survivor', 'deepwater', 'horizon', 'patriot', 'day', 'unlike', 'film', 'wahlbergs', 'character', 'patriot', 'day', 'didnt', 'really', 'exist', 'often', 'come', 'across', 'bundle', 'screenwriting', 'clichés', 'he', 'nursing', 'bum', 'knee', 'recently', 'demoted', 'due', 'insubordination', 'somehow', 'term', 'every', 'cop', 'uniformed', 'otherwise', 'city', 'film', 'focused', 'saunders', 'mostly', 'feel', 'like', 'straight', 'recreation', 'traumatic', 'event', 'occurred', 'le', 'four', 'year', 'ago', 'berg', 'largely', 'well', 'avoid', 'sensationalizing', 'bombing', 'killed', 'wounded', 'others', 'subsequent', 'manhunt', 'claimed', 'life', 'police', 'officer', 'point', 'patriot', 'day', 'feel', 'like', 'glitzy', 'action', 'movie', 'gory', 'piece', 'horror', 'violence', 'day', 'lingered', 'outside', 'effort', 'make', 'victim', 'feel', 'like', 'real', 'people', 'depicting', 'snippet', 'life', 'beforehand', 'wahlberg', 'part', 'cant', 'help', 'make', 'saunders', 'feel', 'like', 'bit', 'stereotype', 'he', 'movie', 'cop', 'film', 'thats', 'otherwise', 'seeking', 'nuance', 'saunders', 'seems', 'supposed', 'stand', 'generally', 'lovable', 'belligerent', 'boston', 'spirit', 'prevailed', 'day', 'marathon', 'berg', 'drill', 'point', 'home', 'far', 'many', 'time', 'bit', 'work', 'immediate', 'aftermath', 'bomb', 'wahlberg', 'successfully', 'communicates', 'angry', 'shaken', 'saunders', 'rather', 'switching', 'hero', 'mode', 'decent', 'job', 'selling', 'trauma', 'hefty', 'attitude', 'return', 'patriot', 'day', 'snap', 'back', 'severe', 'unreality', 'thats', 'bad', 'since', 'film', 'fascinating', 'faithfully', 'conveys', 'confusion', 'day', 'bombing', 'differing', 'opinion', 'clashing', 'ego', 'fbi', 'led', 'agent', 'richard', 'deslauriers', 'kevin', 'bacon', 'take', 'case', 'recreating', 'block', 'attacked', 'bomb', 'inside', 'gigantic', 'warehouse', 'combing', 'surveillance', 'video', 'clue', 'boston', 'police', 'commissioner', 'davis', 'john', 'goodman', 'massachusetts', 'governor', 'deval', 'patrick', 'michael', 'beach', 'boston', 'mayor', 'thomas', 'menino', 'vincent', 'curatola', 'gather', 'offer', 'guidance', 'case', 'saunders', 'present', 'reason', 'mostly', 'providing', 'expertise', 'business', 'around', 'boylston', 'street', 'thorny', 'mucky', 'debate', 'played', 'manhunt', 'best', 'part', 'film', 'berg', 'accurately', 'show', 'deslauriers', 'agonizing', 'whether', 'release', 'picture', 'tsarnaev', 'brother', 'gleaned', 'surveillance', 'camera', 'he', 'fully', 'substantiated', 'theyre', 'bomber', 'hand', 'eventually', 'forced', 'leak', 'medium', 'set', 'action', 'series', 'event', 'led', 'deadly', 'shootout', 'tsarnaev', 'brother', 'watertown', 'simmons', 'play', 'police', 'sergeant', 'berg', 'wise', 'delve', 'utter', 'chaos', 'manhunt', 'included', 'brief', 'informal', 'declaration', 'martial', 'law', 'bizarre', 'bloody', 'standoff', 'brother', 'saw', 'lobbing', 'pipe', 'bomb', 'cop', 'car', 'bedlam', 'word', 'total', 'disorder', 'madness', 'kind', 'violence', 'fear', 'terrorism', 'intended', 'provoke', 'even', 'trying', 'stop', 'boston', 'pd', 'effort', 'capture', 'tsarnaev', 'brother', 'justly', 'depicted', 'heroic', 'crazed', 'random', 'chain', 'event', 'empty', 'angry', 'posturing', 'stick', 'worthy', 'analysis', 'berg', 'dug', 'deeper', 'could', 'great', 'film', 'hand', 'stand', 'he', 'delivered', 'rote', 'occasionally', 'misfirepatriots', 'day', 'best', 'dig', 'past', 'heroism']]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(dfArticleTwo[:1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "dffa69c6-f622-405a-83bd-e83333ff3588",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[['son', 'louisiana', 'man', 'whose', 'father', 'shot', 'killed', 'range', 'baton', 'rouge', 'police', 'asked', 'protester', 'peace', 'violence', 'none', 'whatsoever', 'cameron', 'sterling', 'son', 'alton', 'sterling', 'whose', 'death', 'hand', 'police', 'caught', 'video', 'spoke', 'father', 'protest', 'alton', 'sterling', 'killed', 'baton', 'rouge', 'police', 'july', 'convenience', 'store', 'said', 'selling', 'cd', 'baton', 'rouge', 'police', 'said', 'statement', 'police', 'called', 'convenience', 'store', 'sterling', 'allegedly', 'threatened', 'another', 'patron', 'gun', 'press', 'conference', 'wednesday', 'camerons', 'first', 'since', 'broke', 'sob', 'nationally', 'broadcast', 'press', 'conference', 'mother', 'following', 'father', 'death', 'came', 'talk', 'everyone', 'one', 'death', 'father', 'two', 'feel', 'people', 'general', 'said', 'cameron', 'whose', 'distinctly', 'young', 'voice', 'calm', 'composed', 'front', 'scrum', 'reporter', 'triple', 'convenience', 'store', 'people', 'general', 'matter', 'race', 'come', 'together', 'one', 'united', 'family', 'argument', 'violence', 'crime', 'said', 'cameron', 'yes', 'protest', 'want', 'everyone', 'protest', 'right', 'way', 'protest', 'peace', 'gun', 'drug', 'alcohol', 'violence', 'everyone', 'need', 'protest', 'right', 'way', 'peace', 'violence', 'none', 'whatsoever', 'earlier', 'wednesday', 'interview', 'cbs', 'news', 'cameron', 'said', 'didnt', 'believe', 'police', 'bad', 'police', 'shouldnt', 'punished', 'police', 'crime', 'police', 'dallas', 'texas', 'didnt', 'deserve', 'said', 'cameron', 'alton', 'sterling', 'death', 'spurred', 'department', 'justice', 'investigation', 'protest', 'across', 'country', 'one', 'subject', 'march', 'dallas', 'thursday', 'gunman', 'attacked', 'killed', 'five', 'police', 'officer', 'first', 'two', 'police', 'shooting', 'week', 'including', 'shocking', 'video', 'shooting', 'minnesota', 'man', 'philandro', 'castile', 'aftermath', 'broadcast', 'live', 'facebook', 'girlfriend', 'alton', 'sterling', 'son', 'everyone', 'need', 'protest', 'right', 'way', 'peace']]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(dfArticleThree[:1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "eedb457b-5336-4aaf-83a6-0a685156a7de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def textPreprocessCNN(data):\n",
+    "    # Change the pandas into list\n",
+    "    content_list = data.tolist()\n",
+    "\n",
+    "    # Some texts have location, followed by \"(CNN ___)\" at the beginning of the article --> delete them if it contains them \n",
+    "    for article in range(len(content_list)):\n",
+    "        for word in range(len(content_list[article])):\n",
+    "            if word <= 35 and content_list[article][word] == ')':\n",
+    "                content_list[article] = content_list[article][word + 1:]\n",
+    "                break\n",
+    "            if word >= 36:\n",
+    "                break\n",
+    "\n",
+    "    # Lowercase the words and split them into a list \n",
+    "    new_list = [x.lower().split() for x in content_list]\n",
+    "\n",
+    "    # Delete the numbers and punctuations\n",
+    "    word_list = [[re.sub(r'\\d+|[^\\w\\s]', '', word) for word in article] for article in new_list]\n",
+    "\n",
+    "     # Delete the stopwords and the words that have length less than or equal to 2 and the word \"cnn\" \n",
+    "    stop = stopwords.words('english')\n",
+    "    remove_stopword = []\n",
+    "    for article in word_list:\n",
+    "        lst = [x for x in article if x not in stop and len(x) >= 3 and x != \"cnn\"]\n",
+    "        remove_stopword.append(lst)\n",
+    "        \n",
+    "    # Perform Lemminzation \n",
+    "    stem_lemma_lst = [[lemmatizer.lemmatize(str) for str in lst] for lst in remove_stopword]\n",
+    "    return stem_lemma_lst\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "a08562b6-9396-4802-99bf-0a3271d511c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dfArticleCNN = textPreprocessCNN(dfArticleCNN)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "98108165-1006-4b8e-a018-64f9955a1290",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[['many', 'year', 'world', 'popular', 'emerging', 'market', 'socalled', 'brics', 'brazil', 'russia', 'india', 'china', 'south', 'africabut', 'given', 'russia', 'longer', 'market', 'westerner', 'access', 'following', 'invasion', 'ukraine', 'might', 'time', 'investor', 'stop', 'lumping', 'emerging', 'market', 'togetherthe', 'brics', 'day', 'sun', 'faded', 'said', 'eric', 'winograd', 'senior', 'economist', 'alliancebernsteinseveral', 'major', 'index', 'provider', 'removed', 'russian', 'stock', 'index', 'price', 'zero', 'effectively', 'zero', 'trading', 'share', 'several', 'leading', 'uslisted', 'russian', 'company', 'search', 'engine', 'yandex', 'telecom', 'mt', 'halted', 'moscow', 'stock', 'exchange', 'closed', 'since', 'february', 'day', 'invasionrussia', 'could', 'default', 'debt', 'within', 'daysthe', 'idea', 'country', 'large', 'russia', 'removed', 'index', 'big', 'deal', 'winograd', 'saidread', 'moreit', 'seems', 'likely', 'russia', 'included', 'top', 'emerging', 'market', 'fund', 'anytime', 'soon', 'even', 'westerner', 'still', 'willing', 'invest', 'russian', 'asset', 'clear', 'come', 'nextsome', 'investor', 'asking', 'exposure', 'russia', 'emerging', 'market', 'fund', 'index', 'starting', 'exclude', 'russia', 'still', 'waitandsee', 'game', 'said', 'mychal', 'campos', 'head', 'investing', 'bettermentfor', 'investor', 'looking', 'get', 'exposure', 'emerging', 'market', 'winograd', 'said', 'country', 'looked', 'individuallythe', 'name', 'game', 'differentiation', 'dont', 'invest', 'emerging', 'market', 'based', 'acronym', 'winograd', 'said', 'always', 'strange', 'say', 'argentina', 'south', 'korea', 'thing', 'example', 'theyre', 'forget', 'brics', 'look', 'tick', 'mistto', 'stick', 'acronym', 'shutdown', 'russian', 'stock', 'market', 'essentially', 'turned', 'brics', 'bics', 'could', 'permanent', 'change', 'said', 'rahul', 'sen', 'sharma', 'managing', 'partner', 'indxx', 'global', 'index', 'provider', 'investor', 'ever', 'embrace', 'russia', 'liquidity', 'moot', 'point', 'also', 'hard', 'believe', 'people', 'rush', 'russia', 'anytime', 'soon', 'sen', 'sharma', 'told', 'businesssen', 'sharma', 'said', 'investor', 'may', 'start', 'look', 'emerging', 'market', 'replace', 'russia', 'taiwan', 'south', 'korea', 'brics', 'could', 'become', 'tick', 'added', 'poland', 'turkey', 'mexico', 'intriguing', 'philippine', 'indonesia', 'could', 'dub', 'mexico', 'indonesia', 'south', 'korea', 'turkey', 'mist', 'market', 'people', 'love', 'acronym', 'sen', 'sharma', 'jokedof', 'course', 'emerging', 'market', 'europe', 'think', 'poland', 'inherently', 'risky', 'close', 'geographically', 'russia', 'ukraine', 'central', 'eastern', 'european', 'nation', 'may', 'hard', 'sell', 'western', 'investorswar', 'ukraine', 'sparked', 'scramble', 'dollarsother', 'expert', 'argue', 'investor', 'looking', 'individual', 'company', 'emerging', 'market', 'le', 'country', 'themselvesa', 'typical', 'investor', 'see', 'emerging', 'market', 'class', 'stock', 'piece', 'portfolio', 'said', 'callie', 'cox', 'investment', 'analyst', 'etorothe', 'emerging', 'market', 'landscape', 'changing', 'awhile', 'cox', 'added', 'noting', 'many', 'investor', 'skeptical', 'russia', 'since', 'annexation', 'crimea', 'anxietyrussia', 'longer', 'option', 'investor', 'emerging', 'market', 'arerussia', 'longer', 'option', 'investor', 'emerging', 'market']]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(dfArticleCNN[3:4])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "c3eadc0d-af24-4266-af24-83fc56bee33d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[['sale', 'boost', 'time', 'warner', 'profit', 'quarterly', 'profit', 'medium', 'giant', 'timewarner', 'jumped', 'three', 'month', 'december', 'yearearlier', 'firm', 'one', 'biggest', 'investor', 'google', 'benefited', 'sale', 'highspeed', 'internet', 'connection', 'higher', 'advert', 'sale', 'timewarner', 'said', 'fourth', 'quarter', 'sale', 'rose', 'profit', 'buoyed', 'oneoff', 'gain', 'offset', 'profit', 'dip', 'warner', 'bros', 'le', 'user', 'aol', 'time', 'warner', 'said', 'friday', 'owns', 'searchengine', 'google', 'internet', 'business', 'aol', 'mixed', 'fortune', 'lost', 'subscriber', 'fourth', 'quarter', 'profit', 'lower', 'preceding', 'three', 'quarter', 'however', 'company', 'said', 'aols', 'underlying', 'profit', 'exceptional', 'item', 'rose', 'back', 'stronger', 'internet', 'advertising', 'revenue', 'hope', 'increase', 'subscriber', 'offering', 'online', 'service', 'free', 'timewarner', 'internet', 'customer', 'try', 'sign', 'aols', 'existing', 'customer', 'highspeed', 'broadband', 'timewarner', 'also', 'restate', 'result', 'following', 'probe', 'security', 'exchange', 'commission', 'sec', 'close', 'concluding', 'time', 'warner', 'fourth', 'quarter', 'profit', 'slightly', 'better', 'analyst', 'expectation', 'film', 'division', 'saw', 'profit', 'slump', 'helped', 'boxoffice', 'flop', 'alexander', 'catwoman', 'sharp', 'contrast', 'yearearlier', 'third', 'final', 'film', 'lord', 'ring', 'trilogy', 'boosted', 'result', 'fullyear', 'timewarner', 'posted', 'profit', 'performance', 'revenue', 'grew', 'financial', 'performance', 'strong', 'meeting', 'exceeding', 'fullyear', 'objective', 'greatly', 'enhancing', 'flexibility', 'chairman', 'chief', 'executive', 'richard', 'parson', 'said', 'timewarner', 'projecting', 'operating', 'earnings', 'growth', 'around', 'also', 'expects', 'higher', 'revenue', 'wider', 'profit', 'margin', 'timewarner', 'restate', 'account', 'part', 'effort', 'resolve', 'inquiry', 'aol', 'market', 'regulator', 'already', 'offered', 'pay', 'settle', 'charge', 'deal', 'review', 'sec', 'company', 'said', 'unable', 'estimate', 'amount', 'needed', 'set', 'aside', 'legal', 'reserve', 'previously', 'set', 'intends', 'adjust', 'way', 'account', 'deal', 'german', 'music', 'publisher', 'bertelsmanns', 'purchase', 'stake', 'aol', 'europe', 'reported', 'advertising', 'revenue', 'book', 'sale', 'stake', 'aol', 'europe', 'loss', 'value', 'stake']]\n"
+     ]
+    }
+   ],
+   "source": [
+    "dfArticleBBC = textPreprocessArticles(dfArticleBBC)\n",
+    "print(dfArticleBBC[:1])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "38827ce6-0737-4014-b87f-ddbf4a9327f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "combinedDF = dfArticleOne + dfArticleTwo + dfArticleThree + dfArticleCNN + dfArticleBBC"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "7fb5873a-115a-4c6b-b119-8d1011f10b96",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "148871\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(len(combinedDF))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "4fb3aca2-5b89-44d4-b94b-23bab05eeca6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                             Content\n",
+      "0  [congressional, republican, new, fear, come, h...\n",
+      "1  [bullet, shell, get, counted, blood, dry, voti...\n",
+      "2  [walt, disney, bambi, opened, critic, praised,...\n",
+      "3  [death, may, great, equalizer, isnt, necessari...\n",
+      "4  [north, korea, leader, kim, said, sunday, coun...\n"
+     ]
+    }
+   ],
+   "source": [
+    "allTheContent = [[inner_list] for inner_list in combinedDF]\n",
+    "\n",
+    "allArticlesDataFrame = pd.DataFrame(allTheContent, columns=['Content'])\n",
+    "\n",
+    "print(allArticlesDataFrame.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "id": "0e2310ad-2084-452a-8bbc-61201e389acd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "allArticlesDataFrame['ID'] = range(len(allArticlesDataFrame))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "id": "9e03f8ba-bee0-453a-9d9c-b6bd9831fbcf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                             Content  ID\n",
+      "0  [congressional, republican, new, fear, come, h...   0\n",
+      "1  [bullet, shell, get, counted, blood, dry, voti...   1\n",
+      "2  [walt, disney, bambi, opened, critic, praised,...   2\n",
+      "3  [death, may, great, equalizer, isnt, necessari...   3\n",
+      "4  [north, korea, leader, kim, said, sunday, coun...   4\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(allArticlesDataFrame.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f8dea7a-6a79-462a-ab7d-c5fa386fc9fb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b18dd25-7686-4e36-87ac-70e74c5b3891",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60e0c78f-2501-4ce2-81b3-acd84dad3343",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c578a98-9446-4c12-94aa-e77b32eccbda",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "afb6e4fa-dfda-48c7-91ec-86bc97ca34b3",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Converted the five (articles1, articles2, articles3, bbc, cnn) CSVs into DataFrames using Pandas
Extracted the content and the title/headlines of the new articles 
Cleaned the Data by tokenizing sentences of the raw articles, removing unnecessary information such as the location and the organization name at the beginning of the contents, deleting numbers and words with length less than 3, deleting stopwords, and lemmatizing the words.
Stored the remaining words of the articles into Pandas DataFrame and provided each of them with unique IDs. 